### PR TITLE
prevent performance issues, mainly the recursive substitute in Symbolics

### DIFF
--- a/src/constraint_trees.jl
+++ b/src/constraint_trees.jl
@@ -28,12 +28,12 @@ ConstraintTrees.var_count(x::ParameterQuadraticValue) =
     end
 
 # substitute in the variables as symbolic numbers - useful to construct the KKT function
-ConstraintTrees.substitute(x::ParameterLinearValue, y::Vector{Symbolics.Num}) = C.sum(
+ConstraintTrees.substitute(x::ParameterLinearValue, y::Vector{Symbolics.Num}) = ConstraintTrees.sum(
     (idx == 0 ? x.weights[i] : x.weights[i] * y[idx] for (i, idx) in enumerate(x.idxs)),
     init = Symbolics.Num(0.0),
 )
 
-ConstraintTrees.substitute(x::ParameterQuadraticValue, y::Vector{Symbolics.Num}) = C.sum(
+ConstraintTrees.substitute(x::ParameterQuadraticValue, y::Vector{Symbolics.Num}) = ConstraintTrees.sum(
     (
         let (idx1, idx2) = x.idxs[i]
             (idx1 == 0 ? 1.0 : y[idx1]) * (idx2 == 0 ? 1.0 : y[idx2]) * w

--- a/src/constraint_trees.jl
+++ b/src/constraint_trees.jl
@@ -28,16 +28,18 @@ ConstraintTrees.var_count(x::ParameterQuadraticValue) =
     end
 
 # substitute in the variables as symbolic numbers - useful to construct the KKT function
-ConstraintTrees.substitute(x::ParameterLinearValue, y::Vector{Symbolics.Num}) = ConstraintTrees.sum(
-    (idx == 0 ? x.weights[i] : x.weights[i] * y[idx] for (i, idx) in enumerate(x.idxs)),
-    init = Symbolics.Num(0.0),
-)
+ConstraintTrees.substitute(x::ParameterLinearValue, y::Vector{Symbolics.Num}) =
+    ConstraintTrees.sum(
+        (idx == 0 ? x.weights[i] : x.weights[i] * y[idx] for (i, idx) in enumerate(x.idxs)),
+        init = Symbolics.Num(0.0),
+    )
 
-ConstraintTrees.substitute(x::ParameterQuadraticValue, y::Vector{Symbolics.Num}) = ConstraintTrees.sum(
-    (
-        let (idx1, idx2) = x.idxs[i]
-            (idx1 == 0 ? 1.0 : y[idx1]) * (idx2 == 0 ? 1.0 : y[idx2]) * w
-        end for (i, w) in enumerate(x.weights)
-    ),
-    init = Symbolics.Num(0.0),
-)
+ConstraintTrees.substitute(x::ParameterQuadraticValue, y::Vector{Symbolics.Num}) =
+    ConstraintTrees.sum(
+        (
+            let (idx1, idx2) = x.idxs[i]
+                (idx1 == 0 ? 1.0 : y[idx1]) * (idx2 == 0 ? 1.0 : y[idx2]) * w
+            end for (i, w) in enumerate(x.weights)
+        ),
+        init = Symbolics.Num(0.0),
+    )

--- a/src/constraint_trees.jl
+++ b/src/constraint_trees.jl
@@ -28,12 +28,12 @@ ConstraintTrees.var_count(x::ParameterQuadraticValue) =
     end
 
 # substitute in the variables as symbolic numbers - useful to construct the KKT function
-ConstraintTrees.substitute(x::ParameterLinearValue, y::Vector{Symbolics.Num}) = sum(
+ConstraintTrees.substitute(x::ParameterLinearValue, y::Vector{Symbolics.Num}) = C.sum(
     (idx == 0 ? x.weights[i] : x.weights[i] * y[idx] for (i, idx) in enumerate(x.idxs)),
     init = Symbolics.Num(0.0),
 )
 
-ConstraintTrees.substitute(x::ParameterQuadraticValue, y::Vector{Symbolics.Num}) = sum(
+ConstraintTrees.substitute(x::ParameterQuadraticValue, y::Vector{Symbolics.Num}) = C.sum(
     (
         let (idx1, idx2) = x.idxs[i]
             (idx1 == 0 ? 1.0 : y[idx1]) * (idx2 == 0 ? 1.0 : y[idx2]) * w

--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -191,4 +191,3 @@ function variable_order(m)
     _idxs = sortperm(idxs)
     last.(c)[_idxs]
 end
-

--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -143,7 +143,7 @@ function differentiate(
 
     # substitute in values
     Is, Js, Vs = SparseArrays.findnz(A)
-    vs = float.(Symbolics.value.(Symbolics.substitute(Vs, syms_to_vals)))
+    vs = float.(Symbolics.value.(fast_subst.(Vs, Ref(syms_to_vals))))
     a = SparseArrays.sparse(Is, Js, vs, size(A)...)
     indep_rows = findall_indeps_qr(a) # find independent rows, prevent singularity issues with \
     a_indep = a[indep_rows, :]
@@ -155,7 +155,7 @@ function differentiate(
     =#
 
     Is, Js, Vs = SparseArrays.findnz(B)
-    vs = float.(Symbolics.value.(Symbolics.substitute(Vs, syms_to_vals)))
+    vs = float.(Symbolics.value.(fast_subst.(Vs, Ref(syms_to_vals))))
     b = Array(SparseArrays.sparse(Is, Js, vs, size(B)...)) # no sparse rhs solver, need to make dense
     b_indep = b[indep_rows, :]
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -18,6 +18,13 @@ limitations under the License.
 Changes from copied code are indicated.
 =#
 
+# TODO the substitute of symbolics is (unnecessarily) much more powerful than
+# the "value with these variable values" that we actually need. Unfortunately
+# Symbolics don't realy have anything that would "just do" the simple thing.
+# Thus this hack.
+fast_subst(x::Symbolics.Num, y) = Symbolics.fast_substitute(x, y)
+fast_subst(x, y) = Symbolics.substitute(x, y)
+
 """
 $(TYPEDSIGNATURES)
 
@@ -30,8 +37,8 @@ function constraint_matrix_vector(eqs, m, parameters)
     Js = Int64[]
     Vs = Float64[]
     for (i, (val, rhs)) in enumerate(eqs)
-        rhs = Symbolics.substitute(rhs, parameters)
-        a = Symbolics.substitute(val, parameters)
+        rhs = fast_subst(rhs, parameters)
+        a = fast_subst(val, parameters)
 
         # TODO this seems prone to error
         if Symbolics.value(rhs) != 0.0 && Symbolics.value(rhs) != -0.0

--- a/src/symbolics.jl
+++ b/src/symbolics.jl
@@ -27,23 +27,23 @@ ConstraintTrees.
 Symbolics.substitute(x::ParameterLinearValue, rule::Dict{Symbolics.Num,Float64}) =
     ConstraintTrees.LinearValue(
         x.idxs,
-        Symbolics.value.(Symbolics.substitute(x.weights, rule)),
+        Symbolics.value.(Symbolics.fast_substitute(x.weights, rule)),
     )
 
 Symbolics.substitute(x::ParameterQuadraticValue, rule::Dict{Symbolics.Num,Float64}) =
     ConstraintTrees.QuadraticValue(
         x.idxs,
-        Symbolics.value.(Symbolics.substitute(x.weights, rule)),
+        Symbolics.value.(Symbolics.fast_substitute(x.weights, rule)),
     )
 
 Symbolics.substitute(x::ParameterBetween, rule::Dict{Symbolics.Num,Float64}) =
     ConstraintTrees.Between(
-        Symbolics.value.(Symbolics.substitute(x.lower, rule)),
-        Symbolics.value.(Symbolics.substitute(x.upper, rule)),
+        Symbolics.value.(Symbolics.fast_substitute(x.lower, rule)),
+        Symbolics.value.(Symbolics.fast_substitute(x.upper, rule)),
     )
 
 Symbolics.substitute(x::ParameterEqualTo, rule::Dict{Symbolics.Num,Float64}) =
-    ConstraintTrees.EqualTo(Symbolics.value.(Symbolics.substitute(x.equal_to, rule)))
+    ConstraintTrees.EqualTo(Symbolics.value.(Symbolics.fast_substitute(x.equal_to, rule)))
 
 Symbolics.substitute(x::ConstraintTrees.Between, rule::Dict{Symbolics.Num,Float64}) = x
 


### PR DESCRIPTION
there SHOULD be ideally a better solution -- even the `fast_substitute` does a lot more than we need by trying to substitute whole subexpressions. Given the shape of Symbolics frontend, I guess we'll eventually have to code that manually.

In total the runtime of `optimized_constraints_with_parameters` on a kinetic model of iML1515 is squashed from ~120s to ~0.8s (~0.5s of which is my run of HiGHS).

Also, this uses the CT's preduce in 2 places to prevent possible issues later.

Thanks @HettieC for testcase.